### PR TITLE
Correção da confirmação de venda em modo de testes.

### DIFF
--- a/1.7.x/checkout-transparente/pagseguropro/controllers/front/validation.php
+++ b/1.7.x/checkout-transparente/pagseguropro/controllers/front/validation.php
@@ -356,9 +356,9 @@ class PagSeguroProValidationModuleFrontController extends ModuleFrontController
 		}
 		if (Configuration::get('PAGSEGUROPRO_MODO') == 0) {
 			echo "<br/><br/><h3 style='color:red'><b>Iniciando debug...</b><br/><br/><b>Sistema executando em modo de TESTES!</b></h3><br/><br/>";
-			Tools::dieObject($this->autorizacao);
-			Tools::dieObject($this->insert_data);
-			Tools::dieObject($this->pedido);
+			Tools::dieObject($this->autorizacao, false);
+			Tools::dieObject($this->insert_data, false);
+			Tools::dieObject($this->pedido, false);
 			if (!$bd) {
 				echo "<font color=\"red\"><b>Banco de Dados não atualizado!</b></font><br/><br/>";
 			}


### PR DESCRIPTION
Olá, muito obrigado pelo desenvolvimento do módulo, além de uma pull request este é meu feedback. 

Estive realizando alguns testes no modo local, configurei tudo como recomendado com Https SSL então ele parou de apresentar uns problemas de mensagens de alerta com '0' etc...

Observando o código eu achei estranho que tem ele faz referência aos arquivos de configuração da loja (especificamente no arquivo update.php), por este motivo não consegui utilizar o módulo como link simbólico.

Nesta pull-request modifiquei apenas o código que estava sendo truncado em modo de testes, assim é possível chegar ao link de confirmação do pedido oficial.

Espero ter ajudado em algo. 

Agora testarei em um ambiente de homologação, a fim de confirmar as notificações do sandbox e ter os status dos pedidos atualizados. 

Muito obrigado.